### PR TITLE
Add RepaintBoundary to improve repainting

### DIFF
--- a/lib/src/loading_container_widget.dart
+++ b/lib/src/loading_container_widget.dart
@@ -73,58 +73,60 @@ class _LoadingContainerWidgetState extends State<LoadingContainerWidget> with Si
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: widget.width,
-      height: widget.height,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          Align(
-            alignment: Alignment.center,
-            child: Container(
-              width: widget.width,
-              height: widget.height,
-              decoration: widget.boxDecoration != null
-                  ? widget.boxDecoration?.copyWith(
-                      color: widget.boxDecoration?.color != null ? null : colorOne,
-                      borderRadius: widget.boxDecoration?.borderRadius != null || (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
-                          ? null
-                          : (widget.borderRadius ?? BorderRadius.circular(kRadius)),
-                    )
-                  : BoxDecoration(color: colorOne, borderRadius: widget.borderRadius ?? BorderRadius.circular(kRadius)),
-            ),
-          ),
-          Align(
-            alignment: start ? Alignment.centerLeft : Alignment.centerRight,
-            child: AnimatedBuilder(
-              animation: _animation,
-              builder: (context, child) {
-                return ClipRect(
-                  child: Align(
-                    alignment: start ? Alignment.centerLeft : Alignment.centerRight,
-                    widthFactor: _animation.value,
-                    child: child,
-                  ),
-                );
-              },
+    return RepaintBoundary(
+      child: SizedBox(
+        width: widget.width,
+        height: widget.height,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Align(
+              alignment: Alignment.center,
               child: Container(
                 width: widget.width,
                 height: widget.height,
                 decoration: widget.boxDecoration != null
                     ? widget.boxDecoration?.copyWith(
-                        color: widget.boxDecoration?.color != null ? null : colorTwo,
+                        color: widget.boxDecoration?.color != null ? null : colorOne,
                         borderRadius: widget.boxDecoration?.borderRadius != null || (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
                             ? null
                             : (widget.borderRadius ?? BorderRadius.circular(kRadius)),
                       )
-                    : BoxDecoration(
-                        color: colorTwo,
-                        borderRadius: widget.borderRadius ?? BorderRadius.circular(kRadius),
-                      ),
+                    : BoxDecoration(color: colorOne, borderRadius: widget.borderRadius ?? BorderRadius.circular(kRadius)),
               ),
             ),
-          ),
-        ],
+            Align(
+              alignment: start ? Alignment.centerLeft : Alignment.centerRight,
+              child: AnimatedBuilder(
+                animation: _animation,
+                builder: (context, child) {
+                  return ClipRect(
+                    child: Align(
+                      alignment: start ? Alignment.centerLeft : Alignment.centerRight,
+                      widthFactor: _animation.value,
+                      child: child,
+                    ),
+                  );
+                },
+                child: Container(
+                  width: widget.width,
+                  height: widget.height,
+                  decoration: widget.boxDecoration != null
+                      ? widget.boxDecoration?.copyWith(
+                          color: widget.boxDecoration?.color != null ? null : colorTwo,
+                          borderRadius: widget.boxDecoration?.borderRadius != null || (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
+                              ? null
+                              : (widget.borderRadius ?? BorderRadius.circular(kRadius)),
+                        )
+                      : BoxDecoration(
+                          color: colorTwo,
+                          borderRadius: widget.borderRadius ?? BorderRadius.circular(kRadius),
+                        ),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/loading_container_widget.dart
+++ b/lib/src/loading_container_widget.dart
@@ -25,6 +25,7 @@ class LoadingContainerWidget extends StatefulWidget {
 }
 
 class _LoadingContainerWidgetState extends State<LoadingContainerWidget> with SingleTickerProviderStateMixin {
+  final kRadius = 8.0;
   late Color colorOne;
   late Color colorTwo;
   late AnimationController _animationController;
@@ -72,7 +73,6 @@ class _LoadingContainerWidgetState extends State<LoadingContainerWidget> with Si
 
   @override
   Widget build(BuildContext context) {
-    double kRadius = 8.0;
     return SizedBox(
       width: widget.width,
       height: widget.height,

--- a/lib/src/loading_container_widget.dart
+++ b/lib/src/loading_container_widget.dart
@@ -8,6 +8,7 @@ class LoadingContainerWidget extends StatefulWidget {
   final BorderRadius? borderRadius;
   final BoxDecoration? boxDecoration;
   final Duration? duration;
+
   const LoadingContainerWidget({
     super.key,
     this.width = double.infinity,
@@ -86,8 +87,7 @@ class _LoadingContainerWidgetState extends State<LoadingContainerWidget> with Si
               decoration: widget.boxDecoration != null
                   ? widget.boxDecoration?.copyWith(
                       color: widget.boxDecoration?.color != null ? null : colorOne,
-                      borderRadius: widget.boxDecoration?.borderRadius != null ||
-                              (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
+                      borderRadius: widget.boxDecoration?.borderRadius != null || (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
                           ? null
                           : (widget.borderRadius ?? BorderRadius.circular(kRadius)),
                     )
@@ -113,8 +113,7 @@ class _LoadingContainerWidgetState extends State<LoadingContainerWidget> with Si
                 decoration: widget.boxDecoration != null
                     ? widget.boxDecoration?.copyWith(
                         color: widget.boxDecoration?.color != null ? null : colorTwo,
-                        borderRadius: widget.boxDecoration?.borderRadius != null ||
-                                (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
+                        borderRadius: widget.boxDecoration?.borderRadius != null || (widget.boxDecoration?.shape ?? BoxShape.rectangle) == BoxShape.circle
                             ? null
                             : (widget.borderRadius ?? BorderRadius.circular(kRadius)),
                       )


### PR DESCRIPTION
Wrap top most widget with `RepaintBoundary`. Check this video below

[![RepaintBoundary](https://img.youtube.com/vi/cVAGLDuc2xE/0.jpg)](https://www.youtube.com/watch?v=cVAGLDuc2xE)
[https://www.youtube.com/watch?v=cVAGLDuc2xE](https://www.youtube.com/watch?v=cVAGLDuc2xE)